### PR TITLE
Docker compose docker app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+---
+version: "3.3"
+services:
+  ambition:
+    container_name: ambition
+    restart: always
+    hostname: ambition
+    ports:
+      - 5000:5000
+    build:
+      context: .
+      dockerfile: dockerFile.dev
+    links:
+      - mongo
+  mongo:
+    container_name: mongo
+    image: mongo
+    hostname: mongo
+    ports:
+      - "27017:27017"

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,9 +2,19 @@ const express = require('express')
 const router = express.Router()
 const bcrypt = require('bcrypt')
 const passport = require('passport')
+const mongoose = require('mongoose')
 const flash = require('express-flash')
 const session = require('express-session')
 const methodOverride = require('method-override')
+
+mongoose.connect(process.env.DATABASE_URL, {
+    useNewUrlParser: true
+})
+const db = mongoose.connection
+db.on('error', error => console.error(e))
+db.once('open', () => console.log('Connected to Mongoose'))
+
+
 
 router.get('/', checkNotAuthenticated, (req, res) => {
     res.render('index.ejs')


### PR DESCRIPTION
Related: https://github.com/Lotfi-Arif/Ambition/pull/5

As noticed, with only dockerFile, there's no way to have more services dockerized, we need to make mongo in docker too.
Docker-compose is made just for that.
We create docker-compose.yml, put our service names, port numbers we want  to map out,  and that's it

to run docker now all you need to run is:
docker-compose up --build

--build here will rebuild the images all over again, so that new changes are included.
Also made some basic mongodb connection to verify it works.
